### PR TITLE
Makes Sidebar Items Dissapear when Updates

### DIFF
--- a/src/Modules/ComponentNameList.js
+++ b/src/Modules/ComponentNameList.js
@@ -21,13 +21,13 @@ function processChips(states, name) {
       if(state === 'breakingChange') {
         return returnChip('danger','Breaking Change', name)
       } else if (state === 'changed' || states === 'fixed'){
-        return returnChip('warning','Warning', name)
+        return returnChip('warning','Changed/Fixed', name)
       } else {
-        return returnChip('success','Success', name)
+        return returnChip('success','Added', name)
       }
     }
   } else {
-    return returnChip('success','Success', name)
+    return returnChip('success','Minors', name)
   }
 }
 

--- a/src/Modules/ComponentNameList.js
+++ b/src/Modules/ComponentNameList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { List, Chip } from 'cobalt-react-components';
+import { List, Chip, Icon, EmptyWidget, Color } from 'cobalt-react-components';
 import '../styles.css';
 
 function returnChip(state, label, name) {
@@ -32,23 +32,41 @@ function processChips(states, name) {
 }
 
 function processList(componentStates, onClick, selected) {
-  return componentStates.map((comp, index) => {
+  let listItems = []
+  componentStates.forEach((comp, index) => {
     const {name, states} = comp
-    return(
-      <List.Item key={index} onClick={onClick} active={name === selected}>
-        <List.Item.Content truncated data-value={name}>{name}</List.Item.Content>
-        {processChips(states, name)}
-      </List.Item>
-    )
+    if(states) {
+      listItems.push(
+        <List.Item key={index} onClick={onClick} active={name === selected}>
+          <List.Item.Content truncated data-value={name}>{name}</List.Item.Content>
+          {processChips(states, name)}
+        </List.Item>
+      )
+    }
   });
+  return listItems
 }
 
-const ComponentNameList = ({componentStates, compList, onClick, selected}) => {
+const ComponentNameList = ({componentStates, onClick, selected}) => {
   if(componentStates){
-    return (
+    const list = (
       <List>
         {processList(componentStates, onClick, selected)}
       </List>
+    )
+
+    return (
+      <>
+        {
+          React.Children.count(list.props.children)
+            ? list
+            : <EmptyWidget
+              title='Awesome'
+              message={`Your Project is Updated`}>
+              <Icon name={Icon.CHECK} large color={Color.green[500]} />
+            </EmptyWidget>
+        }
+      </>
     );
   }
 }


### PR DESCRIPTION
When the version of the app is the same as the version of cobalt
there is no need to show a list of all components that are with
the empty state of checked.

There fore, this commit makes it that the sidebar turns into an
empty state which shows the user the app is updated

The design could be better.

(should we use this or not?)